### PR TITLE
Add Besu IBFT2 extradata support to resourceBootstrapIstanbulExtradata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## v0.2.0
 
 **Updated Resources**
-- `quorum_bootstrap_istanbul_extradata`: Added a new argument `ibft2_mode` that creates the `extraData` for genesis JSON used for IBFT2 consensus on Hyperledger Besu.
+- `quorum_bootstrap_istanbul_extradata`: Added a new argument `mode` that creates the `extraData` for genesis JSON based if is IBFT1 or IBFT2 consensus.
 
 ## v0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 
 **Updated Resources**
-- `quorum_bootstrap_istanbul_extradata`: Added a new argument `besu_mode` that creates the `extraData` for genesis JSON used for IBFT2 consensus on Hyperledger Besu. 
+- `quorum_bootstrap_istanbul_extradata`: Added a new argument `ibft2_mode` that creates the `extraData` for genesis JSON used for IBFT2 consensus on Hyperledger Besu. 
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## v0.2.0 (Unreleased)
+
+*TBD*
+
+
+
+**Updated Resources**
+- `quorum_bootstrap_istanbul_extradata`: Added a new argument `besu_mode` that creates the `extraData` for genesis JSON used for IBFT2 consensus on Hyperledger Besu. 
+
+
+
 ## v0.1.0
 
 *Released on March 24th 2021*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,7 @@
-## v0.2.0 (Unreleased)
-
-*TBD*
-
-
+## v0.2.0
 
 **Updated Resources**
-- `quorum_bootstrap_istanbul_extradata`: Added a new argument `ibft2_mode` that creates the `extraData` for genesis JSON used for IBFT2 consensus on Hyperledger Besu. 
-
-
+- `quorum_bootstrap_istanbul_extradata`: Added a new argument `ibft2_mode` that creates the `extraData` for genesis JSON used for IBFT2 consensus on Hyperledger Besu.
 
 ## v0.1.0
 

--- a/README.md
+++ b/README.md
@@ -44,3 +44,14 @@ $ make
 ## Testing the provider
 
 In order to test the provider, you can run `go test ./quorum -v`
+
+## Generate new documentation website
+
+Go to the `website` folder and do:
+```
+go build gen.go
+./gen
+rm -f gen
+```
+
+This will update automatically the website documentation.

--- a/quorum/resource_quorum_bootstrap_istanbul_extradata.go
+++ b/quorum/resource_quorum_bootstrap_istanbul_extradata.go
@@ -20,7 +20,6 @@ func resourceBootstrapIstanbulExtradata() *schema.Resource {
 		Create: resourceBootstrapIstanbulExtradataCreate,
 		Read:   resourceBootstrapIstanbulExtradataRead,
 		Delete: resourceBootstrapIstanbulExtradataDelete,
-		CHANGELOG.md
 		Schema: map[string]*schema.Schema{
 			"istanbul_addresses": {
 				Type:        schema.TypeList,

--- a/quorum/resource_quorum_bootstrap_istanbul_extradata.go
+++ b/quorum/resource_quorum_bootstrap_istanbul_extradata.go
@@ -30,7 +30,7 @@ func resourceBootstrapIstanbulExtradata() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 			},
-			"besu_mode": {
+			"ibft2_mode": {
 				Type:        schema.TypeBool,
 				Description: "generate extradata using RLP encoding mode used by Hyperledger Besu for IBFT2",
 				Optional:    true,
@@ -64,7 +64,7 @@ func resourceBootstrapIstanbulExtradataCreate(d *schema.ResourceData, _ interfac
 		}
 	}
 	vanity := d.Get("vanity").(string)
-	besuMode := d.Get("besu_mode").(bool)
+	besuMode := d.Get("ibft2_mode").(bool)
 
 	createFunc := createForGoQuorum
 	if besuMode {

--- a/quorum/resource_quorum_bootstrap_istanbul_extradata.go
+++ b/quorum/resource_quorum_bootstrap_istanbul_extradata.go
@@ -20,7 +20,7 @@ func resourceBootstrapIstanbulExtradata() *schema.Resource {
 		Create: resourceBootstrapIstanbulExtradataCreate,
 		Read:   resourceBootstrapIstanbulExtradataRead,
 		Delete: resourceBootstrapIstanbulExtradataDelete,
-
+		CHANGELOG.md
 		Schema: map[string]*schema.Schema{
 			"istanbul_addresses": {
 				Type:        schema.TypeList,

--- a/quorum/resource_quorum_bootstrap_istanbul_extradata_test.go
+++ b/quorum/resource_quorum_bootstrap_istanbul_extradata_test.go
@@ -29,3 +29,59 @@ func TestAccResourceBootstrapIstanbulExtradata_whenTypical(t *testing.T) {
 		},
 	})
 }
+
+//TestUnitOfWork_StateUnderTest_ExpectedBehavior
+func TestAccResourceBootstrapIstanbulExtradata_GoQuorum(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  testProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+                    resource "quorum_bootstrap_node_key" "test" {
+						count = 3
+                    }
+
+					resource "quorum_bootstrap_istanbul_extradata" "test" {
+						istanbul_addresses = [
+							"0x8f1e6d8303716516cc9e562e66d09721752a1f83",
+							"0x95167bde9c4c3b12180945bbee9900f69d9ea558",
+							"0xa7c1d1b572f11b02cd6fadc21f1e51f399b4d4cb"
+						]
+					}
+                `,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("quorum_bootstrap_istanbul_extradata.test", "extradata", "0x0000000000000000000000000000000000000000000000000000000000000000f885f83f948f1e6d8303716516cc9e562e66d09721752a1f839495167bde9c4c3b12180945bbee9900f69d9ea55894a7c1d1b572f11b02cd6fadc21f1e51f399b4d4cbb8410000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceBootstrapIstanbulExtradata_Besu(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  testProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+                   resource "quorum_bootstrap_node_key" "test" {
+						count = 3
+                   }
+
+					resource "quorum_bootstrap_istanbul_extradata" "test" {
+						istanbul_addresses = [
+							"0x8f1e6d8303716516cc9e562e66d09721752a1f83",
+							"0x95167bde9c4c3b12180945bbee9900f69d9ea558",
+							"0xa7c1d1b572f11b02cd6fadc21f1e51f399b4d4cb"
+						]
+						besu_mode = true
+					}
+               `,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("quorum_bootstrap_istanbul_extradata.test", "extradata", "0xf869a00000000000000000000000000000000000000000000000000000000000000000f83f948f1e6d8303716516cc9e562e66d09721752a1f839495167bde9c4c3b12180945bbee9900f69d9ea55894a7c1d1b572f11b02cd6fadc21f1e51f399b4d4cb808400000000c0"),
+				),
+			},
+		},
+	})
+}

--- a/quorum/resource_quorum_bootstrap_istanbul_extradata_test.go
+++ b/quorum/resource_quorum_bootstrap_istanbul_extradata_test.go
@@ -75,7 +75,7 @@ func TestAccResourceBootstrapIstanbulExtradata_Besu(t *testing.T) {
 							"0x95167bde9c4c3b12180945bbee9900f69d9ea558",
 							"0xa7c1d1b572f11b02cd6fadc21f1e51f399b4d4cb"
 						]
-						ibft2_mode = true
+						mode = "ibft2"
 					}
                `,
 				Check: resource.ComposeAggregateTestCheckFunc(

--- a/quorum/resource_quorum_bootstrap_istanbul_extradata_test.go
+++ b/quorum/resource_quorum_bootstrap_istanbul_extradata_test.go
@@ -75,7 +75,7 @@ func TestAccResourceBootstrapIstanbulExtradata_Besu(t *testing.T) {
 							"0x95167bde9c4c3b12180945bbee9900f69d9ea558",
 							"0xa7c1d1b572f11b02cd6fadc21f1e51f399b4d4cb"
 						]
-						besu_mode = true
+						ibft2_mode = true
 					}
                `,
 				Check: resource.ComposeAggregateTestCheckFunc(

--- a/quorum/types.go
+++ b/quorum/types.go
@@ -2,6 +2,13 @@ package quorum
 
 import "github.com/ethereum/go-ethereum/common"
 
+type Mode string
+
+const (
+	Ibft1 Mode = "ibft1"
+	Ibft2      = "ibft2"
+)
+
 type BesuExtraData struct {
 	Vanity      []byte
 	Validators  []common.Address

--- a/quorum/types.go
+++ b/quorum/types.go
@@ -1,0 +1,11 @@
+package quorum
+
+import "github.com/ethereum/go-ethereum/common"
+
+type BesuExtraData struct {
+	Vanity      []byte
+	Validators  []common.Address
+	Vote        []byte
+	RoundNumber []byte
+	Seals       [][]byte
+}

--- a/website/docs/r/bootstrap_istanbul_extradata.html.markdown
+++ b/website/docs/r/bootstrap_istanbul_extradata.html.markdown
@@ -28,6 +28,7 @@ resource "quorum_bootstrap_istanbul_extradata" "test" {
 
 ## Argument Reference
 
+- `ibft2_mode` - (Optional) generate extradata using RLP encoding mode used by Hyperledger Besu for IBFT2
 - `istanbul_addresses` - (Required) list of Istanbul address to construct extradata
 - `vanity` - (Optional) Vanity Hex Value to be included in the extradata
 

--- a/website/docs/r/bootstrap_istanbul_extradata.html.markdown
+++ b/website/docs/r/bootstrap_istanbul_extradata.html.markdown
@@ -28,8 +28,8 @@ resource "quorum_bootstrap_istanbul_extradata" "test" {
 
 ## Argument Reference
 
-- `ibft2_mode` - (Optional) generate extradata using RLP encoding mode used by Hyperledger Besu for IBFT2
 - `istanbul_addresses` - (Required) list of Istanbul address to construct extradata
+- `mode` - (Optional) generate extradata using RLP encoding mode. Supported: ibft1 and ibft2. Default is ibft1
 - `vanity` - (Optional) Vanity Hex Value to be included in the extradata
 
 ## Attributes Reference

--- a/website/docs/r/bootstrap_node_key.html.markdown
+++ b/website/docs/r/bootstrap_node_key.html.markdown
@@ -29,4 +29,4 @@ resource "quorum_bootstrap_node_key" "test" {
 - `hex_node_id` - 64-byte hex value represents node ID which is seen being encoded in the username portion of enode URL. E.g.: `enode://[hex node id]@localhost:22000`
 - `istanbul_address` - Address representing public key for the newly created node key. This is mainly used to construct the initial validators set encoded in `extradata` field of the genesis file
 - `node_id` - 32-byte hex value represents the unique identifier for a node
-- `node_key_hex` - Node key as hex. This can be used to populate --nodekeyhex CLI parameter
+- `node_key_hex` - Node key as hex. This can be used to populate `--nodekeyhex` CLI parameter


### PR DESCRIPTION
### Summary

Add support for Besu IBFT2 extradata RLP format to the `resourceBootstrapIstanbulExtradata`

### Changes

* Added new `ibft2_mode` argument to `resourceBootstrapIstanbulExtradata`
* Added unit tests